### PR TITLE
Control ticker stories via WordPress

### DIFF
--- a/app/components/HeaderComponents/Header.vue
+++ b/app/components/HeaderComponents/Header.vue
@@ -6,7 +6,7 @@
         <!-- <advertising id="div-gpt-ad-1550335189859-0" size="banner" unit="DR_Leaderboard"/> -->
       </div>
       <div class="header-sidebar"><OutsideFeed /></div>
-      <Ticker ref="ticker" :tickerStories="tickerStories" />
+      <Ticker ref="ticker" />
     </header>
   </div>
 </template>
@@ -28,12 +28,6 @@ export default {
     return {
       pastHeader: false,
       bannerHeight: null
-    }
-  },
-  computed: {
-    tickerStories() {
-      // FIXME: Make tickerStories a Vuex getter
-      return this.$store.state.tickerStories
     }
   },
   methods: {

--- a/app/components/HeaderComponents/Ticker.vue
+++ b/app/components/HeaderComponents/Ticker.vue
@@ -8,7 +8,11 @@
           :key="story.index"
           v-for="story in tickerStories"
         >
-          <a :href="story.link">{{ story.title }}</a>
+          <nuxt-link 
+            :to="`/articles/${story.slug}`"
+            tag="a">
+            {{ story.title.rendered }}
+          </nuxt-link>
         </span>
       </div>
       <div class="text marquee">
@@ -18,7 +22,7 @@
           :key="story.index"
           v-for="story in tickerStories"
         >
-          <a :href="story.link">{{ story.title }}</a>
+          <a :href="story.link">{{ story.title.rendered }}</a>
         </span>
       </div>
     </div>
@@ -42,9 +46,13 @@ export default {
       // Initially not paused
       type: Boolean,
       default: false
-    },
-    // Array of Ticker stories, passed in via props (should this be a getter unto itself?)
-    tickerStories: Array
+    }
+  },
+  computed: {
+    tickerStories() {
+      // FIXME: Make tickerStories a Vuex getter
+      return this.$store.state.tickerPosts
+    }
   },
   methods: {
     pauseTicker: function() {
@@ -55,6 +63,9 @@ export default {
       // Unpause the ticker
       this.paused = false
     }
+  },
+  mounted() {
+    this.$store.dispatch('getTickerStories')
   }
 }
 </script>

--- a/app/components/HeaderComponents/Ticker.vue
+++ b/app/components/HeaderComponents/Ticker.vue
@@ -1,6 +1,8 @@
 <template lang="html">
   <div aria-hidden="true" class="ticker" @mouseover="pauseTicker()" @mouseout="resumeTicker()">
-    <div :class="{ paused: this.paused }">
+    <div 
+      v-if="tickerStories.length"
+      :class="{ paused: this.paused }">
       <div class="text marquee">
         <span class="ticker-badge">Dirt Rag Newswire</span>
         <span

--- a/app/store/actions.js
+++ b/app/store/actions.js
@@ -1,4 +1,5 @@
 import merge from 'lodash/merge'
+import dayjs from 'dayjs'
 
 export default {
   // Open or close nav drawer
@@ -22,14 +23,23 @@ export default {
     }
   },
 
-  // posts tagged for the ticker, filtered by an expiration in the future
+  // Posts tagged for the ticker, filtered by an expiration in the future
   async getTickerStories({commit, state} , params){
+    // Get current datetime as ISO 8601 string
+    const now = new dayjs().toISOString()
+    // Get posts
+    // We only need the title and slug, so no need for _embed.
     const tickerPosts = await this.$axios.$get('posts', {
       params: {
-        'filter[meta_key]': 'feature_post_in_ticker',
-        'filter[meta_value]': '1'
+        // Look for posts with the 'feature_until' meta field, which shouldn't 
+        // be set if the user didn't tick the 'feature in ticker' box in the UI
+        'filter[meta_key]': 'feature_until',
+        // filter posts with a 'feature_until' date-time value greater than now (the future)
+        'filter[meta_value]': now,
+        'filter[meta_compare]': '>'
       }
     })
+    // Commit ticker posts to the store
     commit('addTickerPosts', tickerPosts)
   },
 

--- a/app/store/actions.js
+++ b/app/store/actions.js
@@ -22,6 +22,17 @@ export default {
     }
   },
 
+  // posts tagged for the ticker, filtered by an expiration in the future
+  async getTickerStories({commit, state} , params){
+    const tickerPosts = await this.$axios.$get('posts', {
+      params: {
+        'filter[meta_key]': 'feature_post_in_ticker',
+        'filter[meta_value]': '1'
+      }
+    })
+    commit('addTickerPosts', tickerPosts)
+  },
+
   // category from slug
   async getCategoryFromSlug({ commit, state }, params) {
     // if we don't have the category in the store, go get it and store it

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -25,29 +25,7 @@ export default () => {
       },
       posts: [],
       pages: [],
-      // TODO: Control tickerStories from WordPress
-      tickerStories: [
-        {
-          title: 'Pivot to return as 2019 DirtFest Sponsor',
-          link: 'https://www.google.com/'
-        },
-        {
-          title: 'Snow Bike Festival is Back',
-          link: 'https://www.google.com/'
-        },
-        {
-          title: 'Canyon releases the new Neuron',
-          link: 'https://www.google.com'
-        },
-        {
-          title: 'Hark! Dirt Rag Issue 208 is on its way!',
-          link: 'https://www.google.com'
-        },
-        {
-          title: 'Remember to shred the vote November 6th',
-          link: 'https://www.google.com'
-        }
-      ],
+      tickerPosts: [],
       // TODO: Control navItems from WordPress
       navItems: [
         {

--- a/app/store/mutations.js
+++ b/app/store/mutations.js
@@ -20,6 +20,16 @@ export default {
       }
     }
   },
+  addTickerPosts(state, posts){
+    for (let post of posts){
+      const i = state.tickerPosts.findIndex(o => o.id === post.id)
+      if (state.tickerPosts[i]){
+        state.tickerPosts[i] = merge(state.tickerPosts[i], post)
+      } else {
+        state.tickerPosts.push(post)
+      }
+    }
+  },
   // paginate
   paginate(state, page) {
     state.pagination.pages.push(page)


### PR DESCRIPTION
Users can check a field in the WordPress UI to feature a post in the ticker until a certain date.