### PR TITLE
"Back to Home" scrolling fix

### DIFF
--- a/app/components/Navigation/Pagination.vue
+++ b/app/components/Navigation/Pagination.vue
@@ -126,9 +126,15 @@ export default {
         !this.$store.state.pagination.current ||
         this.$store.state.pagination.current === 1
       ) {
-        return '/'
+        if (this.$route.params.id !== undefined) {
+          return `/#post-${this.$route.params.id}`
+        } else {
+          return '/'
+        }
       } else {
-        return '/page/' + this.$store.state.pagination.current + '/'
+        return `/page/${this.$store.state.pagination.current}/#post-${
+          this.$route.params.id
+        }`
       }
     },
     backUpText() {
@@ -280,7 +286,7 @@ export default {
       justify-content: center;
       color: #f5f3ef;
       text-decoration: none;
-      padding: 1rem;
+      padding: 1rem 0;
       background: #eb181d;
       svg {
         fill: #f5f3ef;

--- a/app/components/Navigation/Pagination.vue
+++ b/app/components/Navigation/Pagination.vue
@@ -122,19 +122,26 @@ export default {
   // TODO: Comment pagination component
   computed: {
     backUp() {
+      // If the pagination state is non-present or we are on page one...
       if (
         !this.$store.state.pagination.current ||
         this.$store.state.pagination.current === 1
       ) {
+        // and if the route.params.id value is present
         if (this.$route.params.id !== undefined) {
+          // return to the index page with a post-hash to scroll to
           return `/#post-${this.$route.params.id}`
         } else {
+          // else, just return to the top of home
           return '/'
         }
       } else {
+        // If the pagination state is present (e.g., we navigated here from another page),
+        // go to the post-hash on that page
         return `/page/${this.$store.state.pagination.current}/#post-${
           this.$route.params.id
         }`
+        // FIXME: Make this category-aware ;)
       }
     },
     backUpText() {

--- a/app/components/PageComponents/Feed.vue
+++ b/app/components/PageComponents/Feed.vue
@@ -4,6 +4,7 @@
     <template v-for="(feedItem, index) in feedData">
       <PostAtom
         v-if="feedItem.type === 'post'"
+        :id="feedItem.id"
         :key="feedItem.index"
         :slug="feedItem.slug"
         :title="feedItem.title.rendered"

--- a/app/components/PostAtom.vue
+++ b/app/components/PostAtom.vue
@@ -1,10 +1,9 @@
 <template lang="html">
   <div class="post-container" :id="`post-${id}`">
     <div
-      v-lazy:background-image="backgroundImage"
       :class="[mode, isContest ? 'contest' : true, 'post-atom']"
     >
-      <div v-if="mode != 'promotion'" class="post-image">
+      <div class="post-image">
         <div class="post-image-crop">
           <nuxt-link tag="a" :to="{ name: 'article', params: { slug: slug, id: id }}">
             <img alt="" v-lazy="pictureUrl" />
@@ -69,15 +68,6 @@ export default {
     postDate: function() {
       // Pretty-format the post date (January 1, 2019)
       return dayjs(this.date).format('MMMM D, YYYY')
-    },
-    backgroundImage() {
-      // Set the background image if the post mode is a promotion
-      // FIXME: Make background image on promotion posts somewhat more intelligent, please
-      if (this.mode == 'promotion') {
-        return this.pictureUrl
-      } else {
-        return '/og-card.png'
-      }
     }
   }
 }
@@ -86,43 +76,32 @@ export default {
 <style lang="scss">
 .post-atom {
   hyphens: auto;
-}
-
-.post-atom:not(.promotion) {
-  background-image: none !important;
-}
-
-.post-atom.promotion {
-  padding: 4em 2%;
-  position: relative;
-  background-color: #292724;
-  background-size: cover;
-  background-position: center center;
-  border-top: 0.25rem solid #eb181d;
-}
-
-.post-atom.promotion::after {
-  content: '';
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.4);
-}
-
-.post-atom.contest {
-  border: 1px solid #ccc;
-  border-top: 0.25rem solid #eb181d;
-  box-shadow: 0 0.125em 0.25em rgba(0, 0, 0, 0.125);
+  &.promotion {
+    padding: 4em 2%;
+    position: relative;
+    background-color: #292724;
+    overflow: hidden;
+    border: 1px solid #ccc;
+    border-top: 0.25rem solid #eb181d;
+    box-shadow: 0 0.125em 0.25em rgba(0, 0, 0, 0.125);
+  }
 }
 
 .post-image-crop {
   position: relative;
   padding-bottom: 56.25%;
+  height: 0;
+  width: 100%;
   overflow: hidden;
   background: white;
+  .post-atom.promotion & {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .post-image-crop img {
@@ -213,6 +192,8 @@ export default {
 .promotion .post-text {
   position: relative;
   z-index: 1;
+  background: rgba(0, 0, 0, 0.66);
+  padding: 1em;
 }
 
 @media (hover) {
@@ -246,8 +227,6 @@ export default {
   .promotion .post-text {
     grid-column-start: 1;
     grid-column-end: 2;
-    background: rgba(0, 0, 0, 0.66);
-    padding: 1em;
   }
 }
 

--- a/app/components/PostAtom.vue
+++ b/app/components/PostAtom.vue
@@ -1,12 +1,12 @@
 <template lang="html">
-  <div class="post-container">
+  <div class="post-container" :id="`post-${id}`">
     <div
       v-lazy:background-image="backgroundImage"
       :class="[mode, isContest ? 'contest' : true, 'post-atom']"
     >
       <div v-if="mode != 'promotion'" class="post-image">
         <div class="post-image-crop">
-          <nuxt-link tag="a" :to="`/articles/` + slug">
+          <nuxt-link tag="a" :to="{ name: 'article', params: { slug: slug, id: id }}">
             <img alt="" v-lazy="pictureUrl" />
           </nuxt-link>
         </div>
@@ -14,8 +14,8 @@
       <div class="post-text">
         <div class="post-title-block">
           <h4 class="post-title">
-            <span v-html="titleCallout" class="post-title-callout"> </span>
-            <nuxt-link tag="a" :to="`/articles/` + slug">
+            <nuxt-link tag="a" :to="{ name: 'article', params: { slug: slug, id: id }}">
+              <span v-html="titleCallout" class="post-title-callout"> </span>
               <span v-html="title" class="post-title-wrap"> </span>
             </nuxt-link>
           </h4>
@@ -49,6 +49,7 @@ import dayjs from 'dayjs'
 export default {
   name: 'PostAtom',
   props: {
+    id: Number,
     slug: String,
     mode: String,
     pictureUrl: String,
@@ -227,7 +228,7 @@ export default {
   }
 }
 
-@media (min-width: 500px) {
+@media (min-width: 600px) {
   .post-atom {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -5,39 +5,40 @@ module.exports = {
   head: {
     title: pkg.name,
     meta: [{
-        charset: 'utf-8'
-      },
-      {
-        name: 'language',
-        content: 'en-us'
-      },
-      {
-        name: 'viewport',
-        content: 'width=device-width, initial-scale=1'
-      },
-      {
-        hid: 'description',
-        name: 'description',
-        content: pkg.description
-      }
+      charset: 'utf-8'
+    },
+    {
+      name: 'language',
+      content: 'en-us'
+    },
+    {
+      name: 'viewport',
+      content: 'width=device-width, initial-scale=1'
+    },
+    {
+      hid: 'description',
+      name: 'description',
+      content: pkg.description
+    }
     ],
     link: [{
-        rel: 'icon',
-        type: 'image/x-icon',
-        href: '/favicon.ico'
-      },
-      {
-        rel: 'preconnect',
-        href: 'https://content.dirtrag.bike',
-        crossorigin: true
-      }
+      rel: 'icon',
+      type: 'image/x-icon',
+      href: '/favicon.ico'
+    },
+    {
+      rel: 'preconnect',
+      href: 'https://content.dirtrag.bike',
+      crossorigin: true
+    }
     ]
   },
   loading: {
     color: '#eb181d'
   },
   css: ['~/static/global.css'],
-  plugins: [{
+  plugins: [
+    {
       src: '~/plugins/fontawesome.js',
       ssr: true
     },
@@ -61,45 +62,42 @@ module.exports = {
   router: {
     extendRoutes(routes, resolve) {
       return [{
-          path: '/',
-          component: resolve(__dirname, 'pages/index.vue'),
-          name: 'index'
-        },
-        {
-          path: '/page/:page',
-          component: resolve(__dirname, 'pages/index.vue'),
-          name: 'index-page'
-        },
-        {
-          path: '/coolshops',
-          component: resolve(__dirname, 'pages/coolshops.vue'),
-          name: 'page-shops'
-        },
-        {
-          path: '/:slug',
-          component: resolve(__dirname, 'pages/page.vue'),
-          name: 'page'
-        },
-        {
-          path: '/articles/:slug',
-          component: resolve(__dirname, 'pages/article.vue'),
-          name: 'article'
-        },
-        {
-          path: '/category/:slug',
-          component: resolve(__dirname, 'pages/category-index.vue'),
-          name: 'category-index'
-        },
-        {
-          path: '/category/:slug/page/:page',
-          component: resolve(__dirname, 'pages/category-index.vue'),
-          name: 'category-index-page'
-        }
+        path: '/',
+        component: resolve(__dirname, 'pages/index.vue'),
+        name: 'index'
+      },
+      {
+        path: '/page/:page',
+        component: resolve(__dirname, 'pages/index.vue'),
+        name: 'index-page'
+      },
+      {
+        path: '/coolshops',
+        component: resolve(__dirname, 'pages/coolshops.vue'),
+        name: 'page-shops'
+      },
+      {
+        path: '/:slug',
+        component: resolve(__dirname, 'pages/page.vue'),
+        name: 'page'
+      },
+      {
+        path: '/articles/:slug',
+        component: resolve(__dirname, 'pages/article.vue'),
+        name: 'article'
+      },
+      {
+        path: '/category/:slug',
+        component: resolve(__dirname, 'pages/category-index.vue'),
+        name: 'category-index'
+      },
+      {
+        path: '/category/:slug/page/:page',
+        component: resolve(__dirname, 'pages/category-index.vue'),
+        name: 'category-index-page'
+      }
       ]
     }
-    // scrollBehavior: function(to, from, savedPosition) {
-    //   return savedPosition
-    // }
   },
   modules: [
     '@nuxtjs/pwa',

--- a/app/nuxt.config.js
+++ b/app/nuxt.config.js
@@ -97,6 +97,38 @@ module.exports = {
         name: 'category-index-page'
       }
       ]
+    },
+    scrollBehavior(to, from, savedPosition) {
+      // if the returned position is falsy or an empty object,
+      // will retain current scroll position.
+      let position = false
+
+      // if no children detected
+      if (to.matched.length < 2) {
+        // scroll to the top of the page
+        position = { x: 0, y: 0 }
+      } else if (to.matched.some((r) => r.components.default.options.scrollToTop)) {
+        // if one of the children has scrollToTop option set to true
+        position = { x: 0, y: 0 }
+      }
+
+      // savedPosition is only available for popstate navigations (back button)
+      if (savedPosition) {
+        position = savedPosition
+      }
+
+      return new Promise(resolve => {
+        // wait for the out transition to complete (if necessary)
+        window.$nuxt.$once('triggerScroll', () => {
+          // coords will be used if no selector is provided,
+          // or if the selector didn't match any element.
+          if (to.hash && document.querySelector(to.hash)) {
+            // scroll to anchor by returning the selector
+            position = { selector: to.hash }
+          }
+          resolve(position)
+        })
+      })
     }
   },
   modules: [

--- a/app/pages/article.vue
+++ b/app/pages/article.vue
@@ -42,13 +42,13 @@
       </header>
       <div class="article-content">
         <main>
-          <AdHeader />
+          <AdHeader/>
           <div class="article-copy" @click="zoomFigure" v-html="post.content.rendered"/>
           <div v-if="this.post.acf.contest_platform">
             <no-ssr placeholder="Loading contest...">
-              <contest 
+              <contest
                 :key="randomKey"
-                :platform="this.post.acf.contest_platform" 
+                :platform="this.post.acf.contest_platform"
                 :embedCode="this.post.acf.embed_code"
               />
             </no-ssr>
@@ -64,14 +64,13 @@
           </section>
           <section class="article-comments">
             <no-ssr>
-              <comments />
+              <comments/>
             </no-ssr>
           </section>
         </main>
         <aside class="advertising">
           <no-ssr>
-            <ad-sidebar 
-              :sidebarData="ads" />
+            <ad-sidebar :sidebarData="ads"/>
           </no-ssr>
         </aside>
       </div>
@@ -165,10 +164,17 @@ export default {
         return false
       }
     },
-    randomKey(){
-      return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+    randomKey() {
+      return (
+        Math.random()
+          .toString(36)
+          .substring(2, 15) +
+        Math.random()
+          .toString(36)
+          .substring(2, 15)
+      )
     },
-    isMobile: function () {
+    isMobile: function() {
       // Return true if the device user-agent is "mobile" (as deterimined by 'nuxt-device-detect' module)
       if (this.$device.isMobile) {
         return true
@@ -199,7 +205,6 @@ export default {
       }
     }
   },
-  scrollToTop: true,
   transition: {
     name: 'fade',
     mode: 'out-in'
@@ -257,11 +262,19 @@ export default {
     background: #f5f3ef;
   }
   &.has-artwork {
-    .article-title-block { order: 1; }
-    .article-artwork { order: 2; }
+    .article-title-block {
+      order: 1;
+    }
+    .article-artwork {
+      order: 2;
+    }
     @media (min-width: 1000px) {
-      .article-title-block { order: 2; }
-      .article-artwork { order: 1; }
+      .article-title-block {
+        order: 2;
+      }
+      .article-artwork {
+        order: 1;
+      }
     }
   }
 }
@@ -325,7 +338,7 @@ export default {
 
 .article-content {
   padding: 0 2%;
-  border-top: 1px solid rgba(0,0,0,0.1);
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
   @media (min-width: 1000px) {
     padding: 0;
     display: grid;
@@ -350,7 +363,7 @@ main {
 
 aside {
   grid-column: main;
-  @media (min-width: 1000px){
+  @media (min-width: 1000px) {
     grid-column: sidebar;
   }
 }
@@ -372,7 +385,6 @@ aside {
 .article-copy img {
   width: 100%;
 }
-
 
 @media (min-width: 1000px) {
   .article-copy figure {
@@ -418,5 +430,4 @@ aside {
 .article-comments {
   margin-top: 2rem;
 }
-
 </style>

--- a/app/pages/article.vue
+++ b/app/pages/article.vue
@@ -94,6 +94,7 @@ export default {
     AdHeader,
     AdSidebar
   },
+  scrollToTop: true,
   computed: {
     post() {
       // Return the post for whatever post we're looking for in route.params

--- a/app/pages/category-index.vue
+++ b/app/pages/category-index.vue
@@ -1,12 +1,12 @@
 <template>
   <main class="content">
     <section class="feed category-feed">
-      <SectionHeader :sectionMeta="acfFields" />
+      <SectionHeader :sectionMeta="acfFields"/>
       <div class="feed-items">
-        <feed :feedData="feedItems" />
+        <feed :feedData="feedItems"/>
       </div>
       <div v-if="!isMobile" class="sidebar-ads">
-        <ad-sidebar :sidebarData="sidebarAds" />
+        <ad-sidebar :sidebarData="sidebarAds"/>
       </div>
     </section>
   </main>
@@ -38,7 +38,7 @@ export default {
     })
   },
   computed: {
-    isMobile: function () {
+    isMobile: function() {
       // Return true if the device user-agent is "mobile" (as deterimined by 'nuxt-device-detect' module)
       if (this.$device.isMobile) {
         return true
@@ -67,9 +67,9 @@ export default {
       return this.$store.state.advertising.rectangle
     },
     feedItems() {
-      if (this.isMobile){
-        // If the user-agent is "mobile", compose a feed, with an ad 
-        // inserted every 3 posts. We should have: 
+      if (this.isMobile) {
+        // If the user-agent is "mobile", compose a feed, with an ad
+        // inserted every 3 posts. We should have:
         // - 30 posts (set back in the Vuex store as state.postsPerPage),
         // - 10 ad slots (explicitly set back in the Vuex store).
         return compact(flattenDeep(zip(chunk(this.posts, 3), this.ads)))
@@ -78,12 +78,12 @@ export default {
         return this.$store.getters.getCatPostsPage(
           parseInt(this.$route.params.page || 1),
           this.catId
-        ) 
+        )
       }
     },
     sidebarAds() {
       // If the user agent is not "mobile", return ads from the store
-      if (!this.isMobile){
+      if (!this.isMobile) {
         return this.$store.state.advertising.rectangle
       } else {
         // Otherwise return an empty array
@@ -110,7 +110,6 @@ export default {
       ]
     }
   },
-  scrollToTop: false,
   transition: {
     name: 'fade',
     mode: 'out-in'
@@ -151,7 +150,7 @@ export default {
 
 .sidebar-ads {
   grid-column: main;
-  @media (min-width: 1000px){
+  @media (min-width: 1000px) {
     grid-column: sidebar;
   }
 }

--- a/app/pages/coolshops.vue
+++ b/app/pages/coolshops.vue
@@ -78,7 +78,6 @@ export default {
       return this.$store.state.advertising.rectangle
     }
   },
-  scrollToTop: true,
   transition: {
     name: 'fade',
     mode: 'out-in'

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,12 +1,12 @@
 <template>
   <main class="content">
     <section class="feed">
-      <SectionHeader />
+      <SectionHeader/>
       <div class="feed-items">
-        <feed :feedData="feedItems" />
+        <feed :feedData="feedItems"/>
       </div>
       <div v-if="!isMobile" class="sidebar-ads">
-        <ad-sidebar :sidebarData="sidebarAds" />
+        <ad-sidebar :sidebarData="sidebarAds"/>
       </div>
     </section>
   </main>
@@ -37,7 +37,7 @@ export default {
     })
   },
   computed: {
-    isMobile: function () {
+    isMobile: function() {
       // Return true if the device user-agent is "mobile" (as deterimined by 'nuxt-device-detect' module)
       if (this.$device.isMobile) {
         return true
@@ -57,9 +57,9 @@ export default {
       return this.$store.state.advertising.rectangle
     },
     feedItems() {
-      if (this.isMobile){
-        // If the user-agent is "mobile", compose a feed, with an ad 
-        // inserted every 3 posts. We should have: 
+      if (this.isMobile) {
+        // If the user-agent is "mobile", compose a feed, with an ad
+        // inserted every 3 posts. We should have:
         // - 30 posts (set back in the Vuex store as state.postsPerPage),
         // - 10 ad slots (explicitly set back in the Vuex store).
         return compact(flattenDeep(zip(chunk(this.posts, 3), this.ads)))
@@ -67,12 +67,12 @@ export default {
         // If the user-agent is not "mobile", simply return posts.
         return this.$store.getters.getPostsPage(
           parseInt(this.$route.params.page || 1)
-        ) 
+        )
       }
     },
     sidebarAds() {
       // If the user agent is not "mobile", return ads from the store
-      if (!this.isMobile){
+      if (!this.isMobile) {
         return this.$store.state.advertising.rectangle
       } else {
         // Otherwise return an empty array
@@ -95,7 +95,6 @@ export default {
       ]
     }
   },
-  scrollToTop: false,
   transition: {
     name: 'fade',
     mode: 'out-in'
@@ -136,7 +135,7 @@ export default {
 
 .sidebar-ads {
   grid-column: main;
-  @media (min-width: 1000px){
+  @media (min-width: 1000px) {
     grid-column: sidebar;
   }
 }


### PR DESCRIPTION
Adds page anchors for all feed posts and a hash for navigating between the index and article pages. Now scrolls to top of every `index -> index` transition, scrolls to the top of every `index -> article` transition, and returns to the article's hash position in `article -> index` transitions.