### PR TITLE
Return post date formatted, not just date formatted

### DIFF
--- a/app/pages/article.vue
+++ b/app/pages/article.vue
@@ -106,7 +106,7 @@ export default {
     },
     postDate: function() {
       // Pretty-format the post date (January 1, 2019)
-      return dayjs(this.date).format('MMMM D, YYYY')
+      return dayjs(this.post.date).format('MMMM D, YYYY')
     },
     thisUrl() {
       // Prepend our URL to the route path to get an absolute URL without

--- a/app/pages/page.vue
+++ b/app/pages/page.vue
@@ -43,7 +43,7 @@ export default {
     },
     postDate: function() {
       // Pretty-format the post date (January 1, 2019)
-      return dayjs(this.date).format('MMMM D, YYYY')
+      return dayjs(this.post.date).format('MMMM D, YYYY')
     },
     featuredMedia() {
       // Check for the existence of featured media on the post.


### PR DESCRIPTION
Post date on articles should accurately reflect the date of the post, not today's date.

Fixes #49 