### PR TITLE
Horizontal nav

### DIFF
--- a/app/components/HeaderComponents/Header.vue
+++ b/app/components/HeaderComponents/Header.vue
@@ -1,59 +1,27 @@
 <template lang="html">
   <div ref="banner">
-    <header role="banner" :class="{ sticky: pastHeader }">
+    <header role="banner">
       <div class="header-content">
         <NavLogo variant="banner" />
         <HorizontalNav />
       </div>
-      <div class="header-sidebar"><OutsideFeed /></div>
     </header>
   </div>
 </template>
 
 <script>
 import NavLogo from '@/components/Navigation/NavLogo'
-import OutsideFeed from '@/components/HeaderComponents/OutsideFeed'
 import HorizontalNav from '@/components/Navigation/HorizontalNav'
 
 export default {
   components: {
     HorizontalNav,
-    NavLogo,
-    OutsideFeed
-  },
-  data() {
-    return {
-      pastHeader: false,
-      bannerHeight: null
-    }
+    NavLogo
   },
   methods: {
-    scrollHeader() {
-      // On scroll, evaluate window scroll position and decide if we should
-      // fix the header or not
-      const scrollY = window.scrollY
-      const tickerHeight = 30
-      if (scrollY >= tickerHeight) {
-        return true
-      } else {
-        return false
-      }
-    },
     openNav() {
       this.$store.dispatch('openNavDrawer')
     }
-  },
-  beforeMount() {
-    // Add our scroll listener for the fixed header
-    document.addEventListener('scroll', () => {
-      this.pastHeader = this.scrollHeader()
-    })
-  },
-  beforeDestroy() {
-    // Destroy our scroll listener for the fixed header
-    document.removeEventListener('scroll', () => {
-      this.pastHeader = this.scrollHeader()
-    })
   }
 }
 </script>
@@ -65,26 +33,12 @@ header[role='banner'] {
   background: #292724;
   position: relative;
   z-index: 1;
-  /* transition: background-color 0.2s ease, height 0.2s ease; */
   display: grid;
   grid-template-columns:
-    [full-start] minmax(1em, 1fr) [main-start] minmax(0, 45em)
+    [full-start] minmax(1em, 1fr) [main-start] minmax(0, 72.5em)
     [main-end] minmax(1em, 1fr) [full-end];
   grid-auto-rows: auto;
   grid-row-gap: 0;
-  @media (min-width: 800px) {
-    grid-template-columns:
-      [full-start] minmax(1em, 1fr) [main-start] minmax(0, 45em)
-      [main-end sidebar-start] 300px [sidebar-end] minmax(1em, 1fr) [full-end];
-    grid-column-gap: 2em;
-  }
-  @media (min-width: 1200px) {
-    grid-template-columns:
-      [full-start] minmax(1em, 1fr)
-      [main-start] minmax(0, 62.5em)
-      [main-end sidebar-start] 300px [sidebar-end]
-      minmax(1em, 1fr) [full-end];
-  }
 }
 
 header a {
@@ -101,64 +55,11 @@ header a.nuxt-link-exact-active {
   color: #eb181d;
 }
 
-.block {
-  position: relative;
-  @media (min-width: 812px) {
-    height: 122px;
-  }
-  background: #292724;
-}
-
-header.sticky {
-  // position: fixed;
-  // z-index: 2;
-  // background: transparent;
-  div[data-google-query-id] {
-    display: none;
-  }
-  .header-content {
-    position: relative;
-  }
-}
-
 .header-content {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 1rem 0;
   grid-column: main;
-}
-
-header .header-sidebar {
-  grid-column: sidebar;
-  position: relative;
-}
-
-@media (max-width: 812px) {
-  header .outside-player {
-    display: none;
-  }
-}
-
-header .outside-player:not(:empty) {
-  width: 300px;
-  position: absolute;
-  top: 100px;
-}
-
-header.sticky .outside-player {
-  position: fixed;
-  top: 1.5em;
-}
-
-header .ticker {
-  grid-column: full;
-  grid-row: 1;
-}
-
-header.sticky .ticker {
-  visibility: hidden;
-  height: 0px;
-  grid-row: 1;
 }
 </style>

--- a/app/components/HeaderComponents/Header.vue
+++ b/app/components/HeaderComponents/Header.vue
@@ -1,8 +1,9 @@
 <template lang="html">
-  <div ref="banner" :class="{ block: pastHeader }">
+  <div ref="banner">
     <header role="banner" :class="{ sticky: pastHeader }">
       <div class="header-content">
         <NavLogo variant="banner" />
+        <HorizontalNav />
       </div>
       <div class="header-sidebar"><OutsideFeed /></div>
     </header>
@@ -10,17 +11,15 @@
 </template>
 
 <script>
-// import Advertising from '@/components/Advertising'
 import NavLogo from '@/components/Navigation/NavLogo'
 import OutsideFeed from '@/components/HeaderComponents/OutsideFeed'
-// import Ticker from '@/components/HeaderComponents/Ticker'
+import HorizontalNav from '@/components/Navigation/HorizontalNav'
 
 export default {
   components: {
-    // Advertising,
+    HorizontalNav,
     NavLogo,
     OutsideFeed
-    // Ticker
   },
   data() {
     return {
@@ -111,11 +110,14 @@ header a.nuxt-link-exact-active {
 }
 
 header.sticky {
-  position: fixed;
-  z-index: 2;
-  background: transparent;
+  // position: fixed;
+  // z-index: 2;
+  // background: transparent;
   div[data-google-query-id] {
     display: none;
+  }
+  .header-content {
+    position: relative;
   }
 }
 
@@ -145,6 +147,7 @@ header .outside-player:not(:empty) {
 }
 
 header.sticky .outside-player {
+  position: fixed;
   top: 1.5em;
 }
 

--- a/app/components/Navigation/HorizontalNav.vue
+++ b/app/components/Navigation/HorizontalNav.vue
@@ -1,0 +1,39 @@
+<template lang="html">
+  <div>
+    <nav>
+      <NavItem
+        v-for="navLink in navLinks"
+        :key="navLink.index"
+        :text="navLink.name"
+        :link="navLink.href"
+      />
+    </nav>
+  </div>
+</template>
+
+<script>
+// import Search from '@/components/Search'
+import NavItem from '@/components/Navigation/NavItem'
+
+export default {
+  name: 'HorizontalNav',
+  components: {
+    NavItem
+  },
+  computed: {
+    navLinks: function() {
+      // FIXME: Make navlinks a Vuex getter
+      return this.$store.state.navItems
+    }
+  },
+  methods: {},
+  watch: {}
+}
+</script>
+
+<style lang="scss" scoped>
+nav {
+  display: flex;
+  flex-direction: row;
+}
+</style>

--- a/app/components/Navigation/HorizontalNav.vue
+++ b/app/components/Navigation/HorizontalNav.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <div>
+  <div class="horizontal-nav">
     <nav>
       <NavItem
         v-for="navLink in navLinks"
@@ -32,8 +32,23 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.horizontal-nav {
+  flex-grow: 1;
+  display: none;
+  @media (min-width: 800px) {
+    display: block;
+  }
+}
+
 nav {
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
+  @media (min-width: 800px) {
+    padding-left: 3rem;
+  }
+  @media (min-width: 1200px) {
+    padding-left: 10em;
+  }
 }
 </style>

--- a/app/components/Navigation/NavDrawer.vue
+++ b/app/components/Navigation/NavDrawer.vue
@@ -62,7 +62,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .nav-drawer-wrapper {
   position: fixed;
   z-index: 5;
@@ -104,6 +104,28 @@ export default {
   justify-content: stretch;
   min-width: 20em;
   width: 50%;
+}
+
+.nav-drawer nav .nav-item {
+  display: block;
+  background: #eb181d;
+  width: 100%;
+  color: #f5f3ef;
+  text-align: center;
+  padding: 2.5vh;
+  cursor: pointer;
+  text-decoration: none;
+  margin-bottom: 0.25em;
+  @media (min-width: 1000px) {
+    font-size: 1.5rem;
+  }
+  &:hover {
+    color: #292724;
+    background: #f5f3ef;
+  }
+  &.nav-item-external {
+    background: rgb(14, 121, 193);
+  }
 }
 
 .nav-drawer-header {

--- a/app/components/Navigation/NavItem.vue
+++ b/app/components/Navigation/NavItem.vue
@@ -22,34 +22,15 @@ export default {
 }
 </script>
 
-<style lang="css">
+<style lang="scss">
 .nav-item {
-  display: block;
-  background: #eb181d;
-  width: 100%;
-  color: #f5f3ef;
   font-family: 'Libre Franklin', sans-serif;
+  color: white;
   font-weight: 900;
   font-size: 1.2rem;
-  text-align: center;
-  padding: 2.5vh;
-  cursor: pointer;
   text-decoration: none;
-  margin-bottom: 0.25em;
-}
-
-@media (min-width: 1000px) {
-  .nav-item {
-    font-size: 1.5rem;
+  &:hover {
+    color: #eb181d;
   }
-}
-
-.nav-item.nav-item-external {
-  background: rgb(14, 121, 193);
-}
-
-.nav-item:hover {
-  color: #292724;
-  background: #f5f3ef;
 }
 </style>

--- a/app/components/Navigation/NavLogo.vue
+++ b/app/components/Navigation/NavLogo.vue
@@ -54,6 +54,9 @@ export default {
   padding: 0 0.33em;
   margin: 0;
   cursor: pointer;
+  @media (min-width: 800px) {
+    display: none;
+  }
 }
 
 .nav-toggle:hover {

--- a/app/components/PageComponents/AdSidebar.vue
+++ b/app/components/PageComponents/AdSidebar.vue
@@ -16,6 +16,7 @@
         />
       </div>
     </div>
+    <OutsideFeed />
     <template v-for="ad in sidebarData">
       <advertising :id="ad.id" :size="ad.size" :unit="ad.name" :key="ad.index"/>
     </template>
@@ -25,13 +26,15 @@
 <script>
 import Advertising from '@/components/Advertising'
 import PostAtom from '@/components/PostAtom'
+import OutsideFeed from '@/components/HeaderComponents/OutsideFeed'
 
 export default {
   name: 'adSidebar',
   props: ['sidebarData'],
   components: {
     Advertising,
-    PostAtom
+    PostAtom,
+    OutsideFeed
   },
   computed: {
     contestPosts: function() {

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -56,7 +56,7 @@ export default () => {
           href: '/category/opinion'
         },
         {
-          name: 'Subscribe to Dirt Rag Today',
+          name: 'Subscribe',
           href:
             'https://w1.buysub.com/pubs/RG/DRM/DRM_subpage_print_dig.jsp?cds_page_id=164525'
         }


### PR DESCRIPTION
Adds a horizontal nav in the header and toggles the visibility of the nav drawer toggle (triple line) with a media query. Also (perhaps prematurely) moves the Outside player into the sidebar to make room for the entire menu.

Fixes #54 and #53 