### PR TITLE
Fix Search box interaction

### DIFF
--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -5,10 +5,15 @@
       type="text"
       tabindex="0"
       placeholder="Type your search term, press Enter to search."
-      @blur="clearInput"
       v-model.lazy="query"
     >
-    <button v-if="query !== ''" class="search-clear" @click="clearInput">Clear</button>
+    <button 
+      v-if="query !== ''" 
+      class="search-clear" 
+      @click="clearInput"
+    >
+      Clear & Close
+    </button>
     <div v-if="results && query !== ''" class="search-results">
       <div class="search-header">
         Search results for

--- a/app/pages/article.vue
+++ b/app/pages/article.vue
@@ -278,8 +278,15 @@ export default {
   position: relative;
   display: flex;
   flex-direction: column;
+  margin-top: 78px;
+  @media (min-width: 800px){
+    margin-top: 108.781px;
+  }
   @media (min-width: 1000px) {
     background: #f5f3ef;
+  }
+  @media (min-width: 1150px){
+    margin-top: 67.5625px;
   }
   &.has-artwork {
     .article-title-block {

--- a/app/pages/page.vue
+++ b/app/pages/page.vue
@@ -121,10 +121,17 @@ export default {
   position: relative;
   display: flex;
   flex-direction: column;
+  margin-top: 78px;
+  @media (min-width: 800px){
+    margin-top: 108.781px;
+  }
   @media (min-width: 1000px) {
     background: #f5f3ef;
     min-height: 12.5em;
     justify-content: center;
+  }
+  @media (min-width: 1150px){
+    margin-top: 67.5625px;
   }
   &.has-artwork {
     .page-title-block {


### PR DESCRIPTION
Reverts to old Search box behavior, but relabels button to "Clear & Close," rather than just "Clear." This is temporary until we get the new full page of search results implemented.

Also adjusts some padding on page headers to make room for the sticky navigation.